### PR TITLE
为CloudFlareDDNS加入定时更新的功能

### DIFF
--- a/cfddns/cfddns/scripts/cfddns_config.sh
+++ b/cfddns/cfddns/scripts/cfddns_config.sh
@@ -181,7 +181,7 @@ start)
 	fi
 	;;
 update)
-	echo_date 触发更新
+	echo_date 触发更新 >> $LOG_FILE
 	check_update >> $LOG_FILE
 	;;
 esac

--- a/cfddns/cfddns/scripts/cfddns_config.sh
+++ b/cfddns/cfddns/scripts/cfddns_config.sh
@@ -128,14 +128,38 @@ check_update(){
 	echo_date "======================================"
 }
 
+# 计划运行自动更新
+set_interval_update(){
+	username=`nvram show|grep http_username|awk -F '=' '{print $2}'`
+	filename=/tmp/var/spool/cron/crontabs/$username
+	if [ ! -f $filename ]
+	then
+		echo_date 计划文件不存在，将创建计划文件
+		touch $filename
+	else
+		echo_date 计划文件已存在
+		sed -i '/S99cfddns.sh/d' $filename
+	fi
+	[ "$cfddns_update_interval" = "" ] && cfddns_update_interval="30"
+	echo -e "\n*/$cfddns_update_interval * * * *  sh /koolshare/init.d/S99cfddns.sh update">>$filename
+	sed -i '/^[  ]*$/d' $filename
+	echo_date 计划文件更新成功
+	service restart_crontab > NUL
+	echo_date 已启动计划
+}
+
 # add_cfddns_cru(){
 # 	sed -i '/cfddns/d' /var/spool/cron/crontabs/* >/dev/null 2>&1
 # 	cru a cfddns "0 */$cfddns_refresh_time * * * /koolshare/scripts/cfddns_config.sh update"
 # }
 # 
-# stop_cfddns(){
-# 	sed -i '/cfddns/d' /var/spool/cron/crontabs/* >/dev/null 2>&1
-# }
+
+stop_cfddns(){
+	# sed -i '/cfddns/d' /var/spool/cron/crontabs/* >/dev/null 2>&1
+	username=`nvram show|grep http_username|awk -F '=' '{print $2}'`
+	filename=/tmp/var/spool/cron/crontabs/$username
+	sed -i '/S99cfddns.sh/d' $filename
+}
 
 # ====================================used by init or cru====================================
 case $1 in
@@ -157,19 +181,21 @@ start)
 	fi
 	;;
 update)
+	echo_date 触发更新
 	check_update >> $LOG_FILE
 	;;
 esac
 # ====================================submit by web====================================
 case $2 in
 1)
-	#此处为web提交动设计
+	#此处为web提交设计
 	echo "" > $LOG_FILE
 	http_response "$1"
 	if [ "$cfddns_enable" == "1" ];then
 		[ ! -L "/koolshare/init.d/S99cfddns.sh" ] && ln -sf /koolshare/scripts/cfddns_config.sh /koolshare/init.d/S99cfddns.sh
 		echo_date "======================================" >> $LOG_FILE
 		check_update >> $LOG_FILE
+		set_interval_update >> $LOG_FILE
 	else
 		echo_date "关闭CloudFlare DDNS!" >> $LOG_FILE
 		stop_cfddns

--- a/cfddns/cfddns/uninstall.sh
+++ b/cfddns/cfddns/uninstall.sh
@@ -6,3 +6,8 @@ rm -rf /koolshare/res/icon-cfddns.png
 rm -rf /koolshare/scripts/cfddns*.sh
 rm -rf /koolshare/scripts/uninstall_cfddns.sh
 rm -rf /koolshare/webs/Module_cfddns.asp
+
+# 删除crontab中的配置
+username=`nvram show|grep http_username|awk -F '=' '{print $2}'`
+filename=/tmp/var/spool/cron/crontabs/$username
+sed -i '/S99cfddns.sh/d' $filename

--- a/cfddns/cfddns/webs/Module_cfddns.asp
+++ b/cfddns/cfddns/webs/Module_cfddns.asp
@@ -89,7 +89,7 @@ var dbus = {};
 var _responseLen;
 var noChange = 0;
 var x = 5;
-var params_inp = ['cfddns_email', 'cfddns_akey', 'cfddns_zid', 'cfddns_name', 'cfddns_domain', 'cfddns_ttl', 'cfddns_method'];
+var params_inp = ['cfddns_email', 'cfddns_akey', 'cfddns_zid', 'cfddns_name', 'cfddns_domain', 'cfddns_ttl', 'cfddns_method', 'cfddns_update_interval'];
 var params_chk = ['cfddns_enable', 'cfddns_proxied'];
 //var params_chk = ['cfddns_enable', 'cfddns_proxied', 'cfddns_ipv6'];
 
@@ -156,6 +156,10 @@ function get_status1(){
 }
 
 function save(){
+	if($("#cfddns_update_interval").val()>59 || $("#cfddns_update_interval").val()<5){
+		alert("定时周期必须介于5与59之间");
+		return;
+	}
 	var dbus_new = {}
 	$("#show_btn2").trigger("click");
 	// collect data from input and checkbox
@@ -409,6 +413,12 @@ function reload_Soft_Center(){
 													<th title="设置解析TTL，免费版的范围是120-86400,设置1为自动,默认为1">生存时间(TTL) [?]</th>
 													<td>
 														<input type="text" maxlength="64" id="cfddns_ttl" name="cfddns_ttl" class="input_ss_table" style="width:130px;" autocomplete="off" autocorrect="off" autocapitalize="off" value="1" />
+													</td>
+												</tr>
+												<tr>
+													<th title="每多少分钟进行一次更新，最低5分钟，最多59分钟">定时周期(5~59分钟)</th>
+													<td>
+														<input type="number" min="5" max="59" id="cfddns_update_interval" name="cfddns_update_interval" class="input_ss_table" style="width:130px;" autocomplete="off" autocorrect="off" autocapitalize="off" value="5" />
 													</td>
 												</tr>
 												<tr>


### PR DESCRIPTION
作者你好，本人下载CloudFlareDDNS后发现没有定时更新的功能很是不方便，经阅读代码发现您已经写了一点点开头并因为某种原因搁置了，本人实现后提交该pull req来完善
本人使用AC68U进行测试，核心功能正常运行。唯一想到可能出bug的地方是用户名的获取，因为crontab文件需要以用户名命名，本人从nvram取到该值，此处可能有本人没能测试到的问题